### PR TITLE
Work around duplicate account

### DIFF
--- a/New-AcmeCertificate.ps1
+++ b/New-AcmeCertificate.ps1
@@ -32,7 +32,7 @@ Set-PAServer -DirectoryUrl $AcmeDirectory
 $account = Get-PAAccount
 if (-not $account) {
     # New account
-    $account = New-PAAccount -Contact $AcmeContact -AcceptTOS
+    $account = New-PAAccount -Contact $AcmeContact -AcceptTOS -Force
 }
 elseif ($account.contact -ne "mailto:$AcmeContact") {
     # Update account contact

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ variables:
 - name: letsEncryptHostname
   value: acme-v02.api.letsencrypt.org
 - name: AcmeContact
-  value: tim@homevalet.co
+  value: security@homevalet.co
 - group: Cloudflare
 
 schedules:


### PR DESCRIPTION
In the last cert run we ran into an error due to a duplicate account. It's not clear to me why this is occurring, but since accounts are simply emails registered for purposes of notifications, it's fairly benign if another is added. This works around it by forcing a new account in the event of this happening.

This also changes the email address associated with the notifications to be security@homevalet.co