### PR TITLE
HV-3895 Fixes cert renewal failure

### DIFF
--- a/acme-update-steps.yml
+++ b/acme-update-steps.yml
@@ -75,7 +75,7 @@ steps:
   displayName: Delete cer files in staging directory leaving the zip
   inputs:
     SourceFolder: '$(Build.ArtifactStagingDirectory)'
-    Contents: '*.cer'
+    Contents: '**/*.cer'
 
 # Publish those intermediate certificates
 - task: PublishBuildArtifacts@1

--- a/acme-update-steps.yml
+++ b/acme-update-steps.yml
@@ -60,7 +60,7 @@ steps:
     Contents: '**/$(letsEncryptHostname)/**/$(hostNameFilePath)/**/chain*.cer'
     TargetFolder: $(Build.ArtifactStagingDirectory)
     CleanTargetFolder: true
-    flattenFolders: true
+    flattenFolders: false
 
 - task: ArchiveFiles@2
   displayName: Zip em!


### PR DESCRIPTION
 - Remove the flatten file portion of artifact capture so all of the relevant certs are captured. 